### PR TITLE
Log message when filter didn't match a test case

### DIFF
--- a/output.js
+++ b/output.js
@@ -65,6 +65,9 @@ function finish(config, state) {
     const error_count = utils.count(tasks, t => t.status === 'error');
     const skipped = tasks.filter(t => t.status === 'skipped');
     const expectedToFail = tasks.filter(t => t.expectedToFail);
+    if (tasks.length === 0 && config.filter) {
+        STATUS_STREAM.write(`No test case found with filter: ${config.filter}\n`);
+    }
     STATUS_STREAM.write(`${success_count} tests passed, ${error_count} tests failed.\n`);
     if (skipped.length > 0) {
         STATUS_STREAM.write(`Skipped ${skipped.length} tests (${skipped.map(s => s.name).join(' ')})\n`);


### PR DESCRIPTION
Sometimes a custom filter passed via the command line won't match any test cases and I got a little confused wether something happened. I didn't make the connection in my head that the filter had a typo in it.

This PR prints an additional message in such a scenario, informing the user that no test cases were found using the supplied filter and that this is why the test count is  0.

Before:

```bash
$ ./run -e local_spa -f my_cool_filter

0 tests passed, 0 tests failed. 
```

After:

```bash
$ ./run -e local_spa -f my_test_case

No test case found with filter: my_cool_filter
0 tests passed, 0 tests failed. 
```