### PR TITLE
Change status format

### DIFF
--- a/output.js
+++ b/output.js
@@ -27,7 +27,8 @@ function status(config, state) {
     const running = tasks.filter(s => s.status === 'running');
     const running_count = running.length;
     const done_count = utils.count(tasks, t => (t.status === 'success') || (t.status === 'error'));
-    const todo_count = utils.count(tasks, t => t.status === 'todo');
+    const failed_count = tasks.filter(t => t.status === 'error').length;
+    const failed_str = failed_count > 0 ? `${failed_count} failed, ` : '';
 
     // Fit output into one line
     // Instead of listing all running tests  (aaa bbb ccc), we write (aaa  +2).
@@ -38,7 +39,7 @@ function status(config, state) {
             running.slice(0, running_show).map(({tc}) => tc.name).join(' ')
             + (running_show < running.length ? '  +' + (running.length - running_show) : '')
         );
-        status_str = `${running_count} running (${running_str}), ${done_count} done, ${todo_count} more`;
+        status_str = `${done_count}/${tasks.length} done, ${failed_str}${running_count} running (${running_str})`;
 
         if (status_str.length < terminal_width) {
             break; // Fits!

--- a/runner.js
+++ b/runner.js
@@ -22,7 +22,7 @@ async function run_task(config, task) {
         task.duration = performance.now() - task.start;
         if (task.expectedToFail && !config.expect_nothing) {
             const etf = (typeof task.expectedToFail === 'string') ? ` (${task.expectedToFail})` : '';
-            output.log(config, `test case ${task.name} SUCCEEDED, but expectedToFail was set${etf}\n`);
+            output.log(config, `PASSED test case ${task.name}, but expectedToFail was set${etf}\n`);
         }
     } catch(e) {
         task.status = 'error';
@@ -54,7 +54,7 @@ async function run_task(config, task) {
             !(config.ignore_errors && (new RegExp(config.ignore_errors)).test(e.stack)) &&
             (config.expect_nothing || !task.expectedToFail));
         if (show_error) {
-            output.log(config, `test case ${task.name} FAILED at ${utils.localIso8601()}:\n${e.stack}\n`);
+            output.log(config, `FAILED test case ${task.name} at ${utils.localIso8601()}:\n${e.stack}\n`);
         }
         if (config.fail_fast) {
             process.exit(3);

--- a/tests/expectedToFail.js
+++ b/tests/expectedToFail.js
@@ -42,18 +42,18 @@ async function run() {
 
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_success')));
-    assert(output.some(o => o.includes('test case normal_failure FAILED')));
-    assert(! output.some(o => o.includes('test case expected_failure_true FAILED')));
-    assert(! output.some(o => o.includes('test case works_except_on_totallybroken FAILED')));
-    assert(output.some(o => o.includes('test case unexpected_success SUCCEEDED')));
+    assert(output.some(o => o.includes('FAILED test case normal_failure')));
+    assert(! output.some(o => o.includes('FAILED test case expected_failure_true')));
+    assert(! output.some(o => o.includes('FAILED test case works_except_on_totallybroken')));
+    assert(output.some(o => o.includes('PASSED test case unexpected_success')));
     assert(! output.some(o => o.includes('test case expected_success')));
 
     output = [];
     runnerConfig.expect_nothing = true;
     await runner.run(runnerConfig, testCases);
-    assert(output.some(o => o.includes('test case normal_failure FAILED')));
-    assert(output.some(o => o.includes('test case expected_failure_true FAILED')));
-    assert(output.some(o => o.includes('test case works_except_on_totallybroken FAILED')));
+    assert(output.some(o => o.includes('FAILED test case normal_failure')));
+    assert(output.some(o => o.includes('FAILED test case expected_failure_true')));
+    assert(output.some(o => o.includes('FAILED test case works_except_on_totallybroken')));
 }
 
 module.exports = {


### PR DESCRIPTION
## Status line

This PR orders the information from importance to the user from left to right. It's best explained by comparing the output side by side.

```bash
# before
4 running (foo bar bob  +1), 47 done, 40 more

# after, adds number of failed tests
33/104 done, 1 failed, 4 running (foo bar bob  +1)
```

## Failure output

Similar to the above the main information that a test has failed is moved to the beginning of the line.

```bash
# before
test case foo FAILED at 2020-02-03T09:45:45.557+01:00:
TimeoutError: waiting for selector ".bob .bar" failed: timeout 4000ms exceeded
	[StackTrace]

# after, put status in front
FAILED test case foo at 2020-02-03T09:45:45.557+01:00:
TimeoutError: waiting for selector ".bob .bar" failed: timeout 4000ms exceeded
	[StackTrace]
```