### PR TITLE
Make message optional in assertEventually and friends

### DIFF
--- a/tests/selftest_assertEventually.js
+++ b/tests/selftest_assertEventually.js
@@ -3,16 +3,20 @@ const assert = require('assert');
 const {assertEventually} = require('../utils');
 
 async function run() {
-    await assert.rejects(assertEventually(() => false, 'Never changed', {timeout: 10, checkEvery: 1}), {
+    await assert.rejects(assertEventually(() => false, {timeout: 10, checkEvery: 1, message: 'Never changed'}), {
         message: 'Never changed (waited 10ms)',
+    });
+
+    await assert.rejects(assertEventually(() => false, {timeout: 10, checkEvery: 1}), {
+        message: 'assertEventually failed (waited 10ms)',
     });
 
     let counter = 0;
     await assertEventually(() => {
         return counter++ > 2;
-    }, 'succeeds eventually', {checkEvery: 1});
+    }, {checkEvery: 1});
 
-    await assert.rejects(assertEventually(() => {throw new Error('crash');}, '(not shown)', {}), {
+    await assert.rejects(assertEventually(() => {throw new Error('crash');}), {
         message: 'crash',
     });
 
@@ -22,7 +26,7 @@ async function run() {
         if (counter < 3) {
             throw new Error('crash');
         }
-    }, 'error suppressed', {checkEvery: 1, crashOnError: false});
+    }, {checkEvery: 1, crashOnError: false});
     assert.strictEqual(counter, 3);
 }
 

--- a/tests/selftest_browser.js
+++ b/tests/selftest_browser.js
@@ -60,7 +60,7 @@ async function run(config) {
     await assertEventually(() => clickCount === 1);
 
     await clickText(page, 'click "this" button');
-    await assertEventually(() => clickCount === 2, 'Expect 2 clicks');
+    await assertEventually(() => clickCount === 2, {message: 'Expect 2 clicks'});
     await assert.rejects(clickText(page, '404', {timeout: 10}), {
         message: 'Unable to find text "404" after 10ms',
     });

--- a/tests/selftest_clickTestId.js
+++ b/tests/selftest_clickTestId.js
@@ -28,7 +28,7 @@ async function run(config) {
     await clickTestId(page, 'first');
     await assertEventually(
         () => assert.deepStrictEqual(clicks, ['first']),
-        'click should have been registered', {crashOnError: false});
+        {mesage: 'click should have been registered', crashOnError: false});
     clicks.splice(0, clicks.length);
 
     await assert.rejects(clickTestId(page, 'invisible', {timeout: 43}), {

--- a/utils.js
+++ b/utils.js
@@ -129,24 +129,25 @@ function localIso8601(date) {
     );
 }
 
-async function assertEventually(testfunc, message, options, _checkEvery=200) {
-    if (typeof options === 'number') {
-        console.trace(`DEPRECATED call to assertEventually with non-option argument ${options}`);
-        options = {
-            timeout: options,
-            checkEvery: _checkEvery,
-            crashOnError: true,
-        };
+async function assertEventually(testfunc, options, _options) {
+    if (typeof options === 'string') {
+        console.trace(`DEPRECATED call to assertEventually with non-option argument ${JSON.stringify(options)}`);
+        if (!_options) {
+            _options = {};
+        }
+        _options.message = options;
+        options = _options;
     } else {
         // Normal call
         if (!options) {
             options = {};
         }
-        options.timeout = options.timeout || 10000;
-        options.checkEvery = options.checkEvery || 200;
-        options.crashOnError = (options.crashOnError === undefined) ? true : options.crashOnError;
+        options.message = options.message || 'assertEventually failed';
     }
-    const {timeout, checkEvery, crashOnError} = options;
+    options.timeout = options.timeout || 10000;
+    options.checkEvery = options.checkEvery || 200;
+    options.crashOnError = (options.crashOnError === undefined) ? true : options.crashOnError;
+    const {timeout, checkEvery, crashOnError, message} = options;
 
     for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
         if (crashOnError) {
@@ -168,24 +169,25 @@ async function assertEventually(testfunc, message, options, _checkEvery=200) {
     throw new Error(`${message} (waited ${timeout}ms)`);
 }
 
-async function assertAsyncEventually(testfunc, message, options, _checkEvery=200) {
-    if (typeof options === 'number') {
-        console.trace(`DEPRECATED call to assertAsyncEventually with non-option argument ${options}`);
-        options = {
-            timeout: options,
-            checkEvery: _checkEvery,
-            crashOnError: true,
-        };
+async function assertAsyncEventually(testfunc, options, _options) {
+    if (typeof options === 'string') {
+        console.trace(`DEPRECATED call to assertAsyncEventually with non-option argument ${JSON.stringify(options)}`);
+        if (!_options) {
+            _options = {};
+        }
+        _options.message = options;
+        options = _options;
     } else {
         // Normal call
         if (!options) {
             options = {};
         }
-        options.timeout = options.timeout || 10000;
-        options.checkEvery = options.checkEvery || 200;
-        options.crashOnError = (options.crashOnError === undefined) ? true : options.crashOnError;
+        options.message = options.message || 'assertAsyncEventually failed';
     }
-    const {timeout, checkEvery, crashOnError} = options;
+    options.timeout = options.timeout || 10000;
+    options.checkEvery = options.checkEvery || 200;
+    options.crashOnError = (options.crashOnError === undefined) ? true : options.crashOnError;
+    const {timeout, checkEvery, crashOnError, message} = options;
 
     for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
         if (crashOnError) {
@@ -207,22 +209,24 @@ async function assertAsyncEventually(testfunc, message, options, _checkEvery=200
     throw new Error(`${message} (waited ${timeout}ms)`);
 }
 
-async function assertAlways(testfunc, message, options, _checkEvery=200) {
-    if (typeof options === 'number') {
-        console.trace(`DEPRECATED call to assertAlways with non-option argument ${options}`);
-        options = {
-            timeout: options,
-            checkEvery: _checkEvery,
-        };
+async function assertAlways(testfunc, options, _options) {
+    if (typeof options === 'string') {
+        console.trace(`DEPRECATED call to assertAlways with non-option argument ${JSON.stringify(options)}`);
+        if (!_options) {
+            _options = {};
+        }
+        _options.message = options;
+        options = _options;
     } else {
         // Normal call
         if (!options) {
             options = {};
         }
-        options.timeout = options.timeout || 10000;
-        options.checkEvery = options.checkEvery || 200;
     }
-    const {timeout, checkEvery} = options;
+    options.message = options.message || 'assertAlways failed';
+    options.timeout = options.timeout || 10000;
+    options.checkEvery = options.checkEvery || 200;
+    const {timeout, checkEvery, message} = options;
 
     for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
         const res = testfunc();


### PR DESCRIPTION
Previously, all of these assertion methods did require a message.
Make the message optional, and part of an options object.