### PR TITLE
Allow dot in test IDs

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -172,9 +172,13 @@ async function waitForText(page, text, {timeout=30000, extraMessage=undefined}={
     }
 }
 
-async function waitForTestId(page, testId, {extraMessage=undefined, timeout=undefined, visible=true} = {}) {
+function _checkTestId(testId) {
     if (typeof testId !== 'string') throw new Error(`Invalid testId type ${testId}`);
-    assert(/^[a-zA-Z0-9_-]+$/.test(testId), `Invalid testId ${JSON.stringify(testId)}`);
+    assert(/^[-a-zA-Z0-9_.]+$/.test(testId), `Invalid testId ${JSON.stringify(testId)}`);
+}
+
+async function waitForTestId(page, testId, {extraMessage=undefined, timeout=undefined, visible=true} = {}) {
+    _checkTestId(testId);
 
     const err = new Error(
         `Failed to find ${visible ? 'visible ' : ''}element with data-testid "${testId}" within ${timeout}ms` +
@@ -295,8 +299,7 @@ async function clickText(page, text, {timeout=30000, checkEvery=200, elementXPat
 }
 
 async function clickTestId(page, testId, {extraMessage=undefined, timeout=30000, visible=true} = {}) {
-    if (typeof testId !== 'string') throw new Error(`Invalid testId type ${testId}`);
-    assert(/^[a-zA-Z0-9_-]+$/.test(testId), `Invalid testId ${JSON.stringify(testId)}`);
+    _checkTestId(testId);
 
     const xpath = `//*[@data-testid="${testId}"]`;
     const extraMessageRepr = extraMessage ? `. ${extraMessage}` : '';

--- a/tests/selftest_waitForTestId.js
+++ b/tests/selftest_waitForTestId.js
@@ -6,7 +6,7 @@ async function run(config) {
     const page = await newPage(config);
     await page.setContent(`
         <div id="foo"></div>
-        <div data-testid="bar">bartext</div>
+        <div data-testid="bar.">bartext</div>
         <div data-testid="invisible" style="display:none;"></div>
     `);
 
@@ -14,7 +14,7 @@ async function run(config) {
         message: 'Failed to find visible element with data-testid "foo" within 1ms. blabla',
     });
 
-    const bar = await waitForTestId(page, 'bar');
+    const bar = await waitForTestId(page, 'bar.');
     assert.strictEqual(await page.evaluate(bar => bar.innerText, bar), 'bartext');
 
     await assert.rejects(waitForTestId(page, 'invisible', {timeout: 101}));


### PR DESCRIPTION
Centralize the testId checking and allow a dot. Move `-` to the beginning of the regular expression character group so that we can easily append future new characters.