### PR TITLE
browser_utils: Use new assertAsyncEventually parameter format

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -97,7 +97,11 @@ async function newPage(config, chrome_args=[]) {
                         })()
                     `
                 })).result.value;
-            }, 'could not toggle preserve options in devtools', 10000, 100);
+            }, {
+                message: 'could not toggle preserve options in devtools',
+                timeout: 10000,
+                checkEvery: 100,
+            });
             await session.detach();
         };
 


### PR DESCRIPTION
This was overlooked when changing the signature.