### PR TITLE
selftest_waitForTestId: bump timeouts

### DIFF
--- a/tests/selftest_waitForTestId.js
+++ b/tests/selftest_waitForTestId.js
@@ -17,8 +17,8 @@ async function run(config) {
     const bar = await waitForTestId(page, 'bar.');
     assert.strictEqual(await page.evaluate(bar => bar.innerText, bar), 'bartext');
 
-    await assert.rejects(waitForTestId(page, 'invisible', {timeout: 101}));
-    await waitForTestId(page, 'invisible', {visible: false, timeout: 102});
+    await assert.rejects(waitForTestId(page, 'invisible', {timeout: 201}));
+    await waitForTestId(page, 'invisible', {visible: false, timeout: 1002});
 
     await closePage(page);
 }


### PR DESCRIPTION
At https://travis-ci.org/boxine/pintf/jobs/647233941 , the timeout of 102 ms (which _should_ be more than enough normally) still failed. Bump it by 10x.