### PR TITLE
Show final test summary even when --quiet is active

### DIFF
--- a/output.js
+++ b/output.js
@@ -55,7 +55,6 @@ function status(config, state) {
 
 
 function finish(config, state) {
-    if (config.quiet) return;
     last_state = null;
     const {tasks} = state;
     assert(tasks);


### PR DESCRIPTION
Quiet mode (`-q` or `--quiet`) is commonly used for parallel CI runs, where we don't want to get flooded with status messages.
But in this mode, we still want to know the final tally of all tests. Always show it.