### PR TITLE
browser/clickText: Match everything

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -287,7 +287,7 @@ async function clickXPath(page, xpath, {timeout=30000, checkEvery=200, message=u
     }
 }
 
-const DEFAULT_CLICKABLE = '//*[local-name()="a" or local-name()="button" or local-name()="input"]';
+const DEFAULT_CLICKABLE = '//*';
 // Click a link or button by its text content
 async function clickText(page, text, {timeout=30000, checkEvery=200, elementXPath=DEFAULT_CLICKABLE, extraMessage=undefined}={}) {
     checkText(text);


### PR DESCRIPTION
It turns out that in practice we often want to click labels, or `<p>` inside `<a>`.