### PR TITLE
Exit successfully if all errors were expected

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,8 +87,7 @@ async function real_main(options={}) {
     }
 
     await render.doRender(config, results);
-
-    const any_errors = results.tests.some(s => s.status === 'error');
+    const any_errors = results.tests.some(s => s.status === 'error' && !s.expectedToFail);
     if (!config.keep_open && any_errors) {
         process.exit(config.exit_zero ? 0 : 3);
     }


### PR DESCRIPTION
In a CI context, we do not want to mark our test run as red if it all failures were expected.