### PR TITLE
browser_utils: Restrict default selection of clickable elements

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -287,7 +287,9 @@ async function clickXPath(page, xpath, {timeout=30000, checkEvery=200, message=u
     }
 }
 
-const DEFAULT_CLICKABLE = '//*[local-name()="a" or local-name()="button" or local-name()="input"]';
+const DEFAULT_UNCLICKABLE_ELEMENTS = ['link', 'html', 'head', 'meta', 'script', 'style', 'title'];
+const DEFAULT_CLICKABLE = (
+    '//*[' + DEFAULT_UNCLICKABLE_ELEMENTS.map(e => `local-name()!="${e}"`).join(' and ') + ']');
 // Click a link or button by its text content
 async function clickText(page, text, {timeout=30000, checkEvery=200, elementXPath=DEFAULT_CLICKABLE, extraMessage=undefined}={}) {
     checkText(text);


### PR DESCRIPTION
Selecting _every_ element was a mistake; this would match stuff like `<meta>`, `<style>`, `<script>`, `<title>` etc. .
Instead, select only the input components plus `<div>`, `<p>`, `<span>` for people who don't like semantic HTML.

This reverts commit 38a6a84c6575069a6d4cb2d63d2d62409b5d459a.