### PR TITLE
clickText: Switch back to a whitelist

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -287,9 +287,9 @@ async function clickXPath(page, xpath, {timeout=30000, checkEvery=200, message=u
     }
 }
 
-const DEFAULT_UNCLICKABLE_ELEMENTS = ['link', 'html', 'head', 'meta', 'script', 'style', 'title'];
+const DEFAULT_CLICKABLE_ELEMENTS = ['a', 'button', 'input', 'label'];
 const DEFAULT_CLICKABLE = (
-    '//*[' + DEFAULT_UNCLICKABLE_ELEMENTS.map(e => `local-name()!="${e}"`).join(' and ') + ']');
+    '//*[' + DEFAULT_CLICKABLE_ELEMENTS.map(e => `local-name()="${e}"`).join(' or ') + ']');
 // Click a link or button by its text content
 async function clickText(page, text, {timeout=30000, checkEvery=200, elementXPath=DEFAULT_CLICKABLE, extraMessage=undefined}={}) {
     checkText(text);

--- a/tests/selftest_browser.js
+++ b/tests/selftest_browser.js
@@ -36,11 +36,16 @@ async function run(config) {
         <head>
         <script>
         document.addEventListener('DOMContentLoaded', () => {
+            const body = document.querySelector('body');
+            const h1 = document.createElement('h1');
+            h1.appendChild(document.createTextNode('do not click "this" button (headline)'));
+            body.appendChild(h1);
+
             const btn = document.createElement('button');
             btn.setAttribute('id', 'clickme');
             btn.appendChild(document.createTextNode('click "this" button'));
             btn.addEventListener('click', countClick);
-            document.querySelector('body').appendChild(btn);
+            body.appendChild(btn);
         });
         </script>
         </head>


### PR DESCRIPTION
The problem with a blacklist is that we are trying to match a button by text.
What happens then is that we match headers, `<p>`, and all other kind of elements which happen to share the same text as the button.