### PR TITLE
Add JSDoc comments for enhanced intellisense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,19 @@
       "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
       "dev": true
     },
+    "@types/node": {
+      "version": "13.7.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
+    },
+    "@types/puppeteer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-2.0.1.tgz",
+      "integrity": "sha512-G8vEyU83Bios+dzs+DZGpAirDmMqRhfFBJCkFrg+A5+6n5EPPHxwBLImJto3qjh0mrBXbLBCyuahhhtTrAfR5g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@types/puppeteer": "^2.0.1",
     "argparse": "^1.0.10",
     "emailjs-imap-client": "^3.0.7",
     "emailjs-mime-parser": "^2.0.5",

--- a/promise_utils.js
+++ b/promise_utils.js
@@ -1,14 +1,21 @@
-// Avoid UnhandledPromiseRejectionWarning if a promise fails before we use it.
-// Use like this:
-// const email_promise = catchLater(getMail(...));
-// await ...
-// const email = await email_promise;
+/**
+ * Avoid UnhandledPromiseRejectionWarning if a promise fails before we use it.
+ * Use like this:
+ * const email_promise = catchLater(getMail(...));
+ * await ...
+ * const email = await email_promise;
+ * @param {Promise<any>} promise 
+ */
 function catchLater(promise) {
     promise.catch(() => undefined);
     return promise;
 }
 
-// await and emit a custom message if it fails
+/**
+ * await and emit a custom message if it fails
+ * @param {Promise<any>} promise 
+ * @param {string} error_message 
+ */
 async function customErrorMessage(promise, error_message) {
     try {
         return await promise;

--- a/utils.js
+++ b/utils.js
@@ -18,6 +18,9 @@ async function readFile(fileName, type) {
     });
 }
 
+/**
+ * @param {number} ms 
+ */
 async function wait(ms) {
     await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -37,6 +40,9 @@ function randomHex() {
         '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'][Math.floor(Math.random() * 16)];
 }
 
+/**
+ * @param {number} len 
+ */
 function randomHexstring(len) {
     let res = '';
     while (len-- > 0) {
@@ -56,7 +62,10 @@ function* range(count) {
     }
 }
 
-// Range as array
+/**
+ * Range as array
+ * @param {number} count 
+ */
 function arange(count) {
     return Array.from(range(count));
 }
@@ -129,6 +138,11 @@ function localIso8601(date) {
     );
 }
 
+/**
+ * @param {() => any} testfunc 
+ * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}} [options] 
+ * @param {*} [_options] 
+ */
 async function assertEventually(testfunc, options, _options) {
     if (typeof options === 'string') {
         console.trace(`DEPRECATED call to assertEventually with non-option argument ${JSON.stringify(options)}`);
@@ -169,6 +183,11 @@ async function assertEventually(testfunc, options, _options) {
     throw new Error(`${message} (waited ${timeout}ms)`);
 }
 
+/**
+ * @param {() => Promise<any>} testfunc 
+ * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}} [options] 
+ * @param {*} [_options] 
+ */
 async function assertAsyncEventually(testfunc, options, _options) {
     if (typeof options === 'string') {
         console.trace(`DEPRECATED call to assertAsyncEventually with non-option argument ${JSON.stringify(options)}`);
@@ -209,6 +228,11 @@ async function assertAsyncEventually(testfunc, options, _options) {
     throw new Error(`${message} (waited ${timeout}ms)`);
 }
 
+/**
+ * @param {() => any} testfunc 
+ * @param {{message?: string, timeout?: number, checkEvery?: number}} [options] 
+ * @param {*} [_options] 
+ */
 async function assertAlways(testfunc, options, _options) {
     if (typeof options === 'string') {
         console.trace(`DEPRECATED call to assertAlways with non-option argument ${JSON.stringify(options)}`);


### PR DESCRIPTION
Most frontend-based editors that leverage the TypeScript compiler under the hood use it to present the user with improved suggestions and basic type checking. These include vscode, WebStorm and Sublime (with plugins). This works because TypeScript can check JavaScript files.

_Note: TypeScript is smart enough to infer most return types, so they're not always explicitly specified._

Before:

<img width="650" alt="Screenshot 2020-03-05 at 20 36 27" src="https://user-images.githubusercontent.com/1062408/76018818-06bf9600-5f21-11ea-99aa-c3264b7c360a.png">

As one can see, vscode has no clue about the type of `page`.


After:

<img width="880" alt="Screenshot 2020-03-05 at 20 35 49" src="https://user-images.githubusercontent.com/1062408/76018850-10e19480-5f21-11ea-9583-24ca53d16b3f.png">

<img width="691" alt="Screenshot 2020-03-05 at 20 39 38" src="https://user-images.githubusercontent.com/1062408/76019074-7766b280-5f21-11ea-9751-593c6b2dc19f.png">
