### PR TITLE
Add support for loading browser extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ node_js:
   - 12
   - node
 
+# Make chrome browser work in non-headless mode
+services:
+  - xvfb
+
 script:
   - ./run --ci
   - make lint

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ The keys are up to you; for example you probably want to have a main entry point
 --devtools            Start browser with devtools open. Implies -V
 --devtools-preserve   Configure devtools to preserve logs and network requests upon navigation. Implies 
                       --devtools
+--extensions [EXTENSION_DIR [EXTENSION_DIR ...]]
+                      Load unpacked browser extensions
 ```
 
 ###### Test runner

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -42,6 +42,19 @@ async function newPage(config, chrome_args=[]) {
     };
     if (!config.headless) {
         params.headless = false;
+
+        // Browser extensions only work in non-headless mode
+        if (config.extensions.length) {
+            const extensions = config.extensions.join(',');
+            
+            args.push(
+                // Without this flag the supplied extensions are not
+                // initialized correctly and need to be refreshed in
+                // the browser's extension ui.
+                `--disable-extensions-except=${extensions}`,
+                `--load-extension=${extensions}`
+            );
+        }
     }
     if (config.slow_mo) {
         params.slowMo = config.slow_mo;

--- a/config.js
+++ b/config.js
@@ -197,6 +197,13 @@ function parseArgs(options) {
         help: 'Configure devtools to preserve logs and network requests upon navigation. Implies --devtools',
         action: 'storeTrue',
     });
+    puppeteer_group.addArgument(['--extensions'], {
+        help: 'Load unpacked browser extensions',
+        action: 'append',
+        nargs: '*',
+        defaultValue: [],
+        metavar: 'EXTENSION_DIR',
+    });
 
     const runner_group = parser.addArgumentGroup({title: 'Test runner'});
     runner_group.addArgument(['-C', '--concurrency'], {

--- a/main.js
+++ b/main.js
@@ -62,6 +62,12 @@ async function real_main(options={}) {
         return;
     }
 
+    // Argparse wraps argument lists with another array
+    if (config.extensions.length) {
+        config.extensions = config.extensions
+            .reduce((acc, item) => acc.concat(item), []);
+    } 
+
     if (args.list) {
         for (const tc of test_cases) {
             console.log(tc.name + (tc.description ? ` (${tc.description})` : ''));

--- a/tests/fixtures/extension/content_script.js
+++ b/tests/fixtures/extension/content_script.js
@@ -1,0 +1,1 @@
+document.body.innerHTML = '<h1>Hello World!</h1>';

--- a/tests/fixtures/extension/manifest.json
+++ b/tests/fixtures/extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 2,
+  "name": "Hello World",
+  "version": "1.0",
+  "description": "Add Hello World to DOM",
+	"permissions": [
+    "tabs",
+    "<all_urls>"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_script.js"],
+      "run_at": "document_end",
+      "match_about_blank": true,
+      "all_frames": true
+    }
+  ]
+}

--- a/tests/selftest_extension.js
+++ b/tests/selftest_extension.js
@@ -20,6 +20,7 @@ async function run(config) {
 
 module.exports = {
     description: 'Check if an unpacked browser extension can be loaded',
+    skip: config => !process.env.CI && config.headless,
     resources: [],
     run,
 };

--- a/tests/selftest_extension.js
+++ b/tests/selftest_extension.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const path = require('path');
+const {closePage, newPage} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage({
+        ...config,
+        headless: false, // Extensions are not loaded in headless mode
+        extensions: [path.join(__dirname, 'fixtures', 'extension')]
+    });
+
+    // Extension can't be injected into toplevel about:blank page.
+    await page.goto('https://www.example.org/');
+    const text = await page.evaluate(() => document.body.textContent);
+
+    assert.equal(text, 'Hello World!');
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'Check if an unpacked browser extension can be loaded',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
This PR adds a new cli flag `--extensions` to load a list of browser extensions. There is a restriction in chrome that they're only loaded in non-headless mode. The cli flag expects a list of directories which points to an unpacked browser extension.

This is useful to enhance the debugging experience, like adding `react-devtools` for easier component inspection.