### PR TITLE
Add an expectedToFail function

### DIFF
--- a/promise_utils.js
+++ b/promise_utils.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+
 /**
  * Avoid UnhandledPromiseRejectionWarning if a promise fails before we use it.
  * Use like this:
@@ -32,7 +34,29 @@ async function customErrorMessage(promise, error_message) {
     }
 }
 
+/**
+ * Mark a code section as expected to fail.
+ * @param {*} config 
+ * @param {string} message
+ * @param {() => any} asyncFunc
+ */
+async function expectedToFail(config, message, asyncFunc) {
+    assert(message);
+    try {
+        await asyncFunc();
+    } catch(e) {
+        e.pintf_expectedToFail = message;
+        throw e;
+    }
+    if (!config.expect_nothing) {
+        throw new Error(
+            `Section mark as expectedToFail (${message}), but succeeded.` +
+            ' Pass in --expect-nothing/-E to ignore this message');
+    }
+}
+
 module.exports = {
     catchLater,
     customErrorMessage,
+    expectedToFail,
 };

--- a/runner.js
+++ b/runner.js
@@ -29,6 +29,9 @@ async function run_task(config, task) {
         task.status = 'error';
         task.duration = performance.now() - task.start;
         task.error = e;
+        if (e.pintf_expectedToFail) {
+            task.expectedToFail = e.pintf_expectedToFail;
+        }
 
         if (config.take_screenshots) {
             try {


### PR DESCRIPTION
Previously, one could mark the entire test as expecting to fail.
By adding
```
await expectedToFail(config, 'broken, see ISSUE-123', async () => {
  defective code here..
});
```
one can now test segments as expected to fail.