### PR TITLE
expectedToFail: assert that third argument was given

### DIFF
--- a/promise_utils.js
+++ b/promise_utils.js
@@ -42,6 +42,7 @@ async function customErrorMessage(promise, error_message) {
  */
 async function expectedToFail(config, message, asyncFunc) {
     assert(message);
+    assert(asyncFunc);
     try {
         await asyncFunc();
     } catch(e) {


### PR DESCRIPTION
In one instance, we forgot this argument. Assert that it's valid.