### PR TITLE
Generate TypeScript definitions on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ screenshots
 
 # Editor
 .vscode/
+
+# Generated types
+*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+*.pdf
+.gitignore
+.travis.yml
+.eslintrc.json
+.vscode/
+.prettierignore
+screenshots
+pintf*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,6 +1182,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -1853,9 +1864,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2862,6 +2873,15 @@
           "requires": {
             "mime-db": "1.43.0"
           }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -2998,9 +3018,10 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -3444,6 +3465,16 @@
           "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
           "requires": {
             "rimraf": "^2.6.3"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3520,6 +3520,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    },
     "undefsafe": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^6.2.2",
     "nodemon": "^1.18.11",
     "puppeteer": "^2.1.0",
+    "rimraf": "^3.0.2",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
@@ -34,7 +35,8 @@
     "test": "./run",
     "lint": "eslint . run",
     "types": "tsc",
-    "prepublishOnly": "npm run types"
+    "clean": "rimraf *.d.ts **/*.d.ts",
+    "prepublishOnly": "npm run clean && npm run types"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.47",
   "description": "parallel integration/end-to-end test framework",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "tests"
   },
@@ -23,14 +24,17 @@
     "deep-equal": "^1.0.1",
     "eslint": "^6.2.2",
     "nodemon": "^1.18.11",
-    "puppeteer": "^2.1.0"
+    "puppeteer": "^2.1.0",
+    "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "puppeteer": "*"
   },
   "scripts": {
     "test": "./run",
-    "lint": "eslint . run"
+    "lint": "eslint . run",
+    "types": "tsc",
+    "prepublishOnly": "npm run types"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+  },
+  "files": ["./index.js"]
+}


### PR DESCRIPTION
This PR generates TypeScript typings based on the JSDoc definitions and allows users to consume `pintf` with strict typings enabled. This will create a type definition file next to the js.

```bash
# Example
foo.js
foo.d.ts
```

An alternative to this PR would be to publish typings separate from this project on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/) `@types/pintf`. Downside is that those would need to be updated manually.