### PR TITLE
Add machine name in locking info

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The keys are up to you; for example you probably want to have a main entry point
 -h, --help            Show this help message and exit.
 -e YOUR_ENVIRONMENTS, --env YOUR_ENVIRONMENTS
                       The environment to test against. Default is local.
+--version             Print version of tests and test framework and exit.
 ```
 
 ###### Output
@@ -141,10 +142,11 @@ The keys are up to you; for example you probably want to have a main entry point
 -J, --json            Write tests results as a JSON file.
 --json-file FILE.json
                       JSON file to write to. Defaults to results.json .
--H, --html            Write tests results as an HTML file.
+-H, --html            Write test results as an HTML file.
 --html-file FILE.html
                       HTML file to write a report to. Defaults to results.html .
---pdf                 Write tests results as a PDF file.
+--pdf                 Write test results as a PDF file. (Now enabled by default)
+--no-pdf              Do not write a PDF report with test results.
 --pdf-file FILE.pdf   PDF file to write a report to. Defaults to results.pdf .
 -M, --markdown        Write tests results as a Markdown file.
 --markdown-file FILE.md
@@ -213,6 +215,8 @@ The keys are up to you; for example you probably want to have a main entry point
                       Disable external locking (via a lockserver)
 --external-locking-url URL
                       Override URL of lockserver
+--display-locking-client
+                      Display the locking client ID we would use if we would lock something now
 ```
 
 

--- a/config.js
+++ b/config.js
@@ -260,6 +260,10 @@ function parseArgs(options) {
         help: 'Override URL of lockserver',
         dest: 'override_external_locking_url',
     });
+    locking_group.addArgument(['--display-locking-client'], {
+        action: 'storeTrue',
+        help: 'Display the locking client ID we would use if we would lock something now',
+    });
 
     const args = parser.parseArgs();
     if (args.json_file !== DEFAULT_JSON_NAME && !args.json) {

--- a/external_locking.js
+++ b/external_locking.js
@@ -107,11 +107,10 @@ function prepare(config) {
     if (! config.external_locking_url) {
         config.no_external_locking = true;
     }
-    config.external_locking_client = `${os.userInfo().username}-${Date.now()}`;
+    config.external_locking_client = `${os.hostname()}-${os.userInfo().username}-${Date.now()}`;
     if (config.locking_verbose) {
         output.log(config, `[exlocking] Client id: ${config.external_locking_client}`);
     }
-
 }
 
 async function refresh(state) {

--- a/runner.js
+++ b/runner.js
@@ -255,6 +255,11 @@ async function run(config, testCases) {
             return;
         }
 
+        if (config.display_locking_client) {
+            console.log(config.external_locking_client);
+            return;
+        }
+
         await locking.init(state);
 
         if (config.concurrency === 0) {


### PR DESCRIPTION
We have one machine currently holding a lock permanently. While we should limit the locking in the first place, in the future we should be able to know where that happens.
Add the machine name in the locking ID, and add an option to output it.

Also regenerate the README.