### PR TITLE
output: Account for skipped test cases

### DIFF
--- a/output.js
+++ b/output.js
@@ -27,7 +27,8 @@ function status(config, state) {
     const running = tasks.filter(s => s.status === 'running');
     const running_count = running.length;
     const done_count = utils.count(tasks, t => (t.status === 'success') || (t.status === 'error'));
-    const failed_count = tasks.filter(t => t.status === 'error').length;
+    const failed_count = utils.count(tasks, t => t.status === 'error');
+    const skipped_count = utils.count(tasks, t => t.status === 'skipped');
     const failed_str = failed_count > 0 ? `${failed_count} failed, ` : '';
 
     // Fit output into one line
@@ -39,7 +40,9 @@ function status(config, state) {
             running.slice(0, running_show).map(({tc}) => tc.name).join(' ')
             + (running_show < running.length ? '  +' + (running.length - running_show) : '')
         );
-        status_str = `${done_count}/${tasks.length} done, ${failed_str}${running_count} running (${running_str})`;
+        status_str = (
+            `${done_count}/${tasks.length - skipped_count} done, ` +
+            `${failed_str}${running_count} running (${running_str})`);
 
         if (status_str.length < terminal_width) {
             break; // Fits!


### PR DESCRIPTION
Previously, when running 111 test cases and 11 skipped, we would display something like `99/111` done, which seems like there's some time to go, but really means that all but one test has finished.