### PR TITLE
Fix crash on pdf generation when --devtools is set

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -510,6 +510,10 @@ async function workaround_setContent(page, html) {
 async function html2pdf(config, path, html, modifyPage=null) {
     const pdfConfig = {...config};
     pdfConfig.headless = true;
+    // The headless option will be overwritten if devtools=true, leading to a
+    // crash when attempting to generate a pdf snapshot. See:
+    // https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#puppeteerdefaultargsoptions
+    pdfConfig.devtools = false;
     const page = await newPage(pdfConfig);
 
     await workaround_setContent(page, html);


### PR DESCRIPTION
Reason being that `--devtools` overwrites `--headless` inside the args parser of puppeteer. See: https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#puppeteerdefaultargsoptions

Error stack:

```bash
Error: Protocol error (Page.printToPDF): PrintToPDF is not implemented
    at Promise (/pintf/node_modules/puppeteer/lib/Connection.js:183:56)
    at new Promise (<anonymous>)
    at CDPSession.send (/pintf/node_modules/puppeteer/lib/Connection.js:182:12)
    at Page.pdf (/pintf/node_modules/puppeteer/lib/Page.js:1004:39)
    at Page.<anonymous> (/pintf/node_modules/puppeteer/lib/helper.js:112:23)
    at html2pdf (/pintf/browser_utils.js:522:20)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)

```