### PR TITLE
Include tags in version determination

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,5 +1,6 @@
 const child_process = require('child_process');
 const {promisify} = require('util');
+const {EOL} = require('os');
 
 async function _cmd(cmd, args, options) {
     return (await (promisify(child_process.execFile)(cmd, args, options))).stdout.trim();
@@ -7,17 +8,22 @@ async function _cmd(cmd, args, options) {
 
 async function testsVersion(config) {
     try {
+        const tagsOutput = await _cmd(
+            'git', ['tag', '--points-at', 'HEAD'], {cwd: config._testsDir});
+        const tags = tagsOutput.split(EOL).filter(line => line);
+        const tagsRepr = (tags.length > 0) ? tags.join('/') + '/' : '';
+
         const gitVersion = await _cmd(
             'git', ['show', '--pretty=format:%h (%ai)', '--no-patch', 'HEAD'],
             {cwd: config._testsDir});
-        const changesStr = await _cmd('git', ['status', '--porcelain'], {cwd: config._testsDir});
+        const changesOutput = await _cmd('git', ['status', '--porcelain'], {cwd: config._testsDir});
         const changedFiles = (
-            changesStr.split('\n')
+            changesOutput.split(EOL)
                 .filter(line => line)
                 .map(line => line.trim().split(/\s+/, 2)[1]));
         const suffix = (changedFiles.length > 0) ? `+changes(${changedFiles.join(' ')})` : '';
 
-        return gitVersion + suffix;
+        return tagsRepr + gitVersion + suffix;
     } catch(e) {
         return 'unknown';
     }


### PR DESCRIPTION
When the current commit is tagged, display the tags as well.

Also clarify variable names: `..Output` is the output of a command.

In addition, use the platform's EOL instead of hardcoding `\n`.