### PR TITLE
Add expectSuccess attribute to expectedToFail section

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -62,7 +62,13 @@ async function run_task(config, task) {
             !(config.ignore_errors && (new RegExp(config.ignore_errors)).test(e.stack)) &&
             (config.expect_nothing || !task.expectedToFail));
         if (show_error) {
-            output.log(config, `FAILED test case ${task.name} at ${utils.localIso8601()}:\n${e.stack}\n`);
+            if (e.pintf_expectedToSucceed) {
+                output.log(
+                    config, `PASSED test case ${task.name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
+            } else {
+                output.log(
+                    config, `FAILED test case ${task.name} at ${utils.localIso8601()}:\n${e.stack}\n`);
+            }
         }
         if (config.fail_fast) {
             process.exit(3);

--- a/tests/expectedToFail_section.js
+++ b/tests/expectedToFail_section.js
@@ -1,0 +1,70 @@
+const assert = require('assert');
+
+const runner = require('../runner');
+const {expectedToFail} = require('../promise_utils');
+
+async function run() {
+    let output = [];
+    const runnerConfig = {
+        no_locking: true,
+        concurrency: 0,
+        quiet: true,
+        env: 'totallybroken',
+        logFunc: (_config, msg) => output.push(msg),
+    };
+
+    const testCases = [{
+        name: 'normal_ok',
+        run: async () => {},
+    }, {
+        name: 'section_fail',
+        run: async config => {
+            await expectedToFail(config, 'error message', async () => {
+                throw new Error('error in section');
+            });
+        },
+    }, {
+        name: 'section_ok',
+        run: async config => {
+            await expectedToFail(config, 'this succeeds but is expected to fail', async () => {});
+        },
+    }, {
+        name: 'section_expectNothing_fail',
+        run: async config => {
+            await expectedToFail(
+                config, 'on this environment, this should work but does not',
+                async () => {throw new Error('should work');},
+                {expectNothing: true},
+            );
+        },
+    }, {
+        name: 'section_expectNothing_ok',
+        run: async config => {
+            await expectedToFail(
+                config, 'on this environment, this should work and does',
+                async () => {},
+                {expectNothing: true});
+        },
+    }];
+
+    await runner.run(runnerConfig, testCases);
+    assert(! output.some(o => o.includes('test case normal_ok')));
+    assert(! output.some(o => o.includes('FAILED test case section_fail')));
+    assert(output.some(o => o.includes('PASSED test case section_ok')));
+    assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
+    assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
+
+    output = [];
+    runnerConfig.expect_nothing = true;
+    await runner.run(runnerConfig, testCases);
+    assert(! output.some(o => o.includes('test case normal_ok')));
+    assert(output.some(o => o.includes('FAILED test case section_fail')));
+    assert(! output.some(o => o.includes('test case section_ok')));
+    assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
+    assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
+}
+
+module.exports = {
+    description: 'The expectedToFail section can be used to mark a part of a test which should fail',
+    run,
+};


### PR DESCRIPTION
With the expectedToFail section, one can mark code that is known to fail (because of existing bugs), e.g.
```
await expectedToFail(config, 'BUG-123', async() => {
    throw new Error('always fails');
});
```

This is great because the failure will not be immediately displayed and the tests will remain green even.

However, sometimes the code _does_ work on some environments.

```
if (config.works) {
    // known good environment
    if (config.env !== 'works') throw new Error('always fails');
} else {
    // known bad environment
    await expectedToFail(config, 'BUG-123', async() => {
        if (config.env !== 'works') throw new Error('always fails');
    });
}
```

But this duplicates the whole body of the `expectedToFail` section.
Instead, we add a parameter `expectNothing`, which can be used to effectively disable the `expectedToFail` marker, like this:

```
await expectedToFail(config, 'BUG-123', async() => {
    if (config.env !== 'works') throw new Error('always fails');
}, {expectNothing: config.env === 'works'});
```

Add tests for this and the general `expectedToFail` section.