### PR TITLE
Allow filtering tests by file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ The keys are up to you; for example you probably want to have a main entry point
 
 ```
 -f REGEXP, --filter REGEXP
-                      Regular expression to match tests to run
+                      Regular expression to match names of tests to run
+-b REGEXP, --filter-body REGEXP
+                      Run only tests whose full code is matched by this regular expression
 -l, --list            List all tests that would be run and exit
 -a, --all, --include-slow-tests
                       Run tests that take a very long time

--- a/config.js
+++ b/config.js
@@ -140,7 +140,11 @@ function parseArgs(options) {
     const selection_group = parser.addArgumentGroup({title: 'Test selection'});
     selection_group.addArgument(['-f', '--filter'], {
         metavar: 'REGEXP',
-        help: 'Regular expression to match tests to run',
+        help: 'Regular expression to match names of tests to run',
+    });
+    selection_group.addArgument(['-b', '--filter-body'], {
+        metavar: 'REGEXP',
+        help: 'Run only tests whose full code is matched by this regular expression',
     });
     selection_group.addArgument(['-l', '--list'], {
         action: 'storeTrue',

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const {promisify} = require('util');
+
+async function loadTests(args, testsDir, globPattern = '*.js') {
+    const testFiles = await promisify(glob.glob)(globPattern, {cwd: testsDir});
+    let tests = testFiles.map(n => ({
+        path: n,
+        name: path.basename(n, path.extname(n)),
+    }));
+
+    if (args.filter) {
+        tests = tests.filter(n => new RegExp(args.filter).test(n.name));
+    }
+    if (args.filter_body) {
+        const bodyFilterRe = new RegExp(args.filter_body);
+        tests = (await Promise.all(tests.map(async test => {
+            const filePath = path.join(testsDir, test.path);
+            const contents = await promisify(fs.readFile)(filePath, {encoding: 'utf-8'});
+            return bodyFilterRe.test(contents) ? test : null;
+        }))).filter(t => t);
+    }
+
+    return tests.map(t => {
+        const tc = require(path.join(testsDir, t.path));
+        tc.name = t.name;
+        return tc;
+    });
+}
+
+module.exports = {
+    loadTests,
+};

--- a/tests/selftest_loader.js
+++ b/tests/selftest_loader.js
@@ -1,0 +1,22 @@
+const assert = require('assert').strict;
+
+const {loadTests} = require('../loader');
+
+async function run(config) {
+    assert.deepStrictEqual(
+        (await loadTests({filter: 'selftest_lo[ao]der'}, config._testsDir)).map(t => t.name),
+        ['selftest_loader'],
+    );
+
+    // random string: he5Eih1ohhhhhhai8sho
+    const byBody = await loadTests({
+        filter: 'selftest_[a-l]',
+        filter_body: 'he5Eih1oh+ai8sho',
+    }, config._testsDir);
+    assert.deepStrictEqual(byBody.map(t => t.name), ['selftest_loader']);
+}
+
+module.exports = {
+    description: 'Test test loading and filtering',
+    run,
+};


### PR DESCRIPTION
Sometimes, despite the best naming, we just want to run all tests referencing all tests that deal with insecure HTTP, or all tests referencing BUG-123 / BUG-456.
The new option `-b`/`--filter-body` enables this, as we can use `-b http:` or `-b 'BUG-(123|456)'`.

Move the test loader into its own submodule.
Remove the TypeScript documentation, as this function is not part of the public pintf API.
Add a simple selftest for the test loader.