### PR TITLE
Add attribute getters

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -439,6 +439,36 @@ async function setLanguage(page, lang) {
 }
 
 /**
+ * Retrieve attribute value of a DOM Element
+ * @param {import('puppeteer').Page} page 
+ * @param {string} selector 
+ * @param {string} name 
+ */
+async function getAttribute(page, selector, name) {
+    await page.waitForSelector(selector);
+    return page.$eval(
+        selector,
+        (el, propName) => {
+            if (propName in el) {
+                const value = el[propName];
+                return propName === 'style' ? value.cssText : value;
+            }
+            return el.getAttribute(propName);
+        },
+        name,
+    );
+}
+
+/**
+ * Get the text content of a given DOM Element.
+ * @param {import('puppeteer').Page} page 
+ * @param {string} selector 
+ */
+async function getText(page, selector) {
+    return getAttribute(page, selector, 'textContent');
+}
+
+/**
  * Get all options of a select as an array of strings, e.g. ['Option A', 'Option B(***)', 'Option C']
  * @param {import('puppeteer').Page} page 
  * @param {import('puppeteer').ElementHandle<HTMLSelectElement>} select 
@@ -536,7 +566,9 @@ module.exports = {
     clickXPath,
     closePage,
     escapeXPathText,
+    getAttribute,
     getSelectOptions,
+    getText,
     html2pdf,
     newPage,
     restoreTimeouts,

--- a/tests/selftest_attributes.js
+++ b/tests/selftest_attributes.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+const {closePage, newPage, getAttribute, getText} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.setContent(`
+        <div style="display:none;" id="a"></div>
+        <input type="checkbox" checked="checked" />
+        <p>Hello <span>World!</span></p>
+    `);
+
+    assert.strictEqual(await getAttribute(page, 'div', 'id'), 'a');
+
+    // Special case for style
+    assert.strictEqual(await getAttribute(page, 'div', 'style'), 'display: none;');
+
+    // Get correct type
+    assert.strictEqual(await getAttribute(page, 'input', 'checked'), true);
+
+    // Text content
+    assert.strictEqual(await getText(page, 'p'), 'Hello World!');
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'Testing browser_utils.waitForVisible.',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
This PR adds two new convenience functions:

- `getAttribute(page, '.my-selector', 'class')` to get any attribute of an element
- `getText(page, '.my-selector')` to get the text content of an element