### PR TITLE
Rename to pentf

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,4 @@
 .vscode/
 .prettierignore
 screenshots
-pintf*.tgz
+pentf*.tgz

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
-# pintf - Parallel INTegration Test Framework
+# pentf - Parallel End-To-End Test Framework
+
+pentf runs end-to-end tests (with or without web browsers, emails, and/or direct HTTP requests) in a highly parallel manner, so that tests bound by client CPU can run while other tests are waiting for an email to arrive or slow external servers to answer.
+
+Tests are written in plain JavaScript, typically using node's built-in [assert](https://nodejs.org/api/assert.html). You can use any other assertion framework too; a test is simply an `async` function which throws an exception to indicate test failure.
+
+Browser tests using [puppeteer](https://pptr.dev/) benefit from special support such as isolation of parallel tests and screenshots of test failures as well as a number of [helper functions](https://boxine.github.io/pentf/modules/_browser_utils_.html), for example to wait for text to become visible.
+
+Depending on the environment (you can set up configurations to run the same tests against dev, stage, prod etc.), tests can be skipped, or marked as _expected to fail_ for test driven development where you write tests first before fixing a bug or implementing a feature.
+A locking system prevents two tests or the same tests on two different machines from accessing a shared resource, e.g. a test account.
+You can review test results in a PDF report.
 
 ## Installation
 
 ```shell
-npm i --save-dev pintf puppeteer
+npm i --save-dev pentf puppeteer
 ```
 
 ## Usage
 
-pintf can be used as a library (A standalone binary is also planned). Create a script named `run` in the directory of your tests, and fill it like this:
+pentf can be used as a library (A standalone binary is also planned). Create a script named `run` in the directory of your tests, and fill it like this:
 
 ```javascript
 #!/usr/bin/env node
-require('pintf').main({
+require('pentf').main({
     rootDir: __dirname,
     description: 'Test my cool application',
 });
@@ -32,13 +42,13 @@ Plop a new `.js` file into `tests/`. Its name will be the test''s name, and it s
 
 ```javascript
 const assert = require('assert');
-const {getMail} = require('pintf/email');
-const {newPage, closePage} = require('pintf/browser_utils');
-const {fetch} = require('pintf/net_utils');
-const {makeRandomEmail} = require('pintf/utils');
+const {getMail} = require('pentf/email');
+const {newPage, closePage} = require('pentf/browser_utils');
+const {fetch} = require('pentf/net_utils');
+const {makeRandomEmail} = require('pentf/utils');
 
 async function run(config) {
-    const email = makeRandomEmail(config, 'pintf_example');
+    const email = makeRandomEmail(config, 'pentf_example');
     const start = new Date();
     const response = await fetch(config, 'https://api.tonie.cloud/v2/users', {
         method: 'POST',
@@ -74,7 +84,7 @@ async function run(config) {
 
 module.exports = {
     run,
-    description: 'pintf test example', // optional description for test reports, can be left out
+    description: 'pentf test example', // optional description for test reports, can be left out
 
     // You can skip the test in some conditions by defining an optional skip method:
     skip: config => config.env === 'prod',
@@ -92,17 +102,17 @@ module.exports = {
 };
 ```
 
-Note that while the above example tests a webpage with [puppeteer](https://github.com/GoogleChrome/puppeteer) and uses pintf's has native support for HTTP requests (in `net_utils`) and email sending (in `email`), tests can be anything – they just have to fail the promise if the test fails.
+Note that while the above example tests a webpage with [puppeteer](https://github.com/GoogleChrome/puppeteer) and uses pentf's has native support for HTTP requests (in `net_utils`) and email sending (in `email`), tests can be anything – they just have to fail the promise if the test fails.
 
-Have a look in the [API documentation](https://boxine.github.io/pintf/index.html) for various helper functions.
+Have a look in the [API documentation](https://boxine.github.io/pentf/index.html) for various helper functions.
 
 ## Configuration
 
-pintf is designed to be run against different configurations, e.g. local/dev/stage/prod. Create JSON files in the `config` subdirectory for each environment. You can also add a programatic configuration by passing a function `defaultConfig` to `pintf.main`; see [pintf's own run](run) for an example. 
+pentf is designed to be run against different configurations, e.g. local/dev/stage/prod. Create JSON files in the `config` subdirectory for each environment. You can also add a programatic configuration by passing a function `defaultConfig` to `pentf.main`; see [pentf's own run](run) for an example. 
 
 The keys are up to you; for example you probably want to have a main entry point. Predefined keys are:
 
-- **`imap`** If you are using the `pintf/email` module to fetch and test emails, configure your imap connection here, like
+- **`imap`** If you are using the `pentf/email` module to fetch and test emails, configure your imap connection here, like
 ```
   "imap": {
     "user": "user@example.com",

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -17,7 +17,7 @@ let tmp_home;
 
 /**
  * Launch a new browser, with a new page (=Tab)
- * @param {*} config The pintf configuration
+ * @param {*} config The pentf configuration
  * @param {string[]} [chrome_args] Additional arguments for Chrome (optional)
  * @returns {import('puppeteer').Page} The puppeteer page handle.
  */
@@ -135,7 +135,7 @@ async function newPage(config, chrome_args=[]) {
     }
 
     if (config._browser_pages) {
-        page._pintf_browser_pages = config._browser_pages;
+        page._pentf_browser_pages = config._browser_pages;
         config._browser_pages.push(page);
     }
 
@@ -146,8 +146,8 @@ async function newPage(config, chrome_args=[]) {
  * @param {import('puppeteer').Page} page 
  */
 async function closePage(page) {
-    if (page._pintf_browser_pages) {
-        remove(page._pintf_browser_pages, p => p === page);
+    if (page._pentf_browser_pages) {
+        remove(page._pentf_browser_pages, p => p === page);
     }
 
     const browser = await page.browser();
@@ -490,14 +490,14 @@ async function getSelectOptions(page, select) {
  */
 async function speedupTimeouts(page, {factor=100, persistent=false}={}) {
     function applyTimeouts(factor) {
-        window._pintf_real_setTimeout = window._pintf_real_setTimeout || window.setTimeout;
+        window._pentf_real_setTimeout = window._pentf_real_setTimeout || window.setTimeout;
         window.setTimeout = (func, delay, ...args) => {
-            return window._pintf_real_setTimeout(func, delay && (delay / factor), ...args);
+            return window._pentf_real_setTimeout(func, delay && (delay / factor), ...args);
         };
 
-        window._pintf_real_setInterval = window._pintf_real_setInterval || window.setInterval;
+        window._pentf_real_setInterval = window._pentf_real_setInterval || window.setInterval;
         window.setInterval = (func, delay, ...args) => {
-            return window._pintf_real_setInterval(func, delay && (delay / factor), ...args);
+            return window._pentf_real_setInterval(func, delay && (delay / factor), ...args);
         };
     }
 
@@ -513,11 +513,11 @@ async function speedupTimeouts(page, {factor=100, persistent=false}={}) {
  */
 async function restoreTimeouts(page) {
     await page.evaluate(() => {
-        if (window._pintf_real_setTimeout) {
-            window.setTimeout = window._pintf_real_setTimeout;
+        if (window._pentf_real_setTimeout) {
+            window.setTimeout = window._pentf_real_setTimeout;
         }
-        if (window._pintf_real_setInterval) {
-            window.setInterval = window._pintf_real_setInterval;
+        if (window._pentf_real_setInterval) {
+            window.setInterval = window._pentf_real_setInterval;
         }
     });
 }

--- a/config.js
+++ b/config.js
@@ -182,7 +182,7 @@ function parseArgs(options) {
     puppeteer_group.addArgument(['--screenshot-directory'], {
         metavar: 'DIR',
         defaultValue: defaultScreenshotDir,
-        help: `Directory to write screenshots to (default: ${process.env.PINTF_GENERIC_HELP ? './screenshots' : '%(defaultValue)s'})`,
+        help: `Directory to write screenshots to (default: ${process.env.PENTF_GENERIC_HELP ? './screenshots' : '%(defaultValue)s'})`,
     });
     puppeteer_group.addArgument(['-s', '--slow-mo'], {
         metavar: 'MS',

--- a/config/local.json
+++ b/config/local.json
@@ -1,5 +1,5 @@
 {
 	"extends": "_common",
 
-	"pintf_boot_lockserver": true
+	"pentf_boot_lockserver": true
 }

--- a/config/localhost.json
+++ b/config/localhost.json
@@ -1,7 +1,7 @@
 {
 	"extends": "_common",
 
-	"pintf_boot_lockserver": false,
-	"external_locking_url": "http://localhost:1524/pintf-localhost",
-	"pintf_lockserver_url": "http://localhost:1524/pintf-internal"
+	"pentf_boot_lockserver": false,
+	"external_locking_url": "http://localhost:1524/pentf-localhost",
+	"pentf_lockserver_url": "http://localhost:1524/pentf-internal"
 }

--- a/lockserver/lockserver.js
+++ b/lockserver/lockserver.js
@@ -19,9 +19,9 @@ function listNamespaces(namespaces, request, response) {
     }).join('\n');
     response.end(`<!DOCTYPE html>
 <html>
-<head><title>pintf lockserver</title></head>
+<head><title>pentf lockserver</title></head>
 <body>
-<p>This is the <a href="https://github.com/boxine/pintf">pintf</a> lockserver demo.</p>
+<p>This is the <a href="https://github.com/boxine/pentf">pentf</a> lockserver demo.</p>
 
 Available namespaces:
 
@@ -230,21 +230,21 @@ async function lockserver(options) {
 }
 
 async function beforeAllTests(config) {
-    if (! config.pintf_boot_lockserver) {
+    if (! config.pentf_boot_lockserver) {
         return;
     }
 
     const serverData = await lockserver({port: 0, keepAliveTimeout: 500});
-    config.pintf_lockserver_url = `http://localhost:${serverData.port}/`;
+    config.pentf_lockserver_url = `http://localhost:${serverData.port}/`;
     if (! config.external_locking_url) {
-        config.external_locking_url = config.pintf_lockserver_url + 'pintf';
+        config.external_locking_url = config.pentf_lockserver_url + 'pentf';
     }
     return serverData;
 }
 
 async function afterAllTests(config, serverData) {
     if (!serverData) { // Nothing configured
-        assert(! config.pintf_boot_lockserver);
+        assert(! config.pentf_boot_lockserver);
         return;
     }
 

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ const {readConfig, parseArgs} = require('./config');
 const {readFile} = require('./utils');
 const runner = require('./runner');
 const render = require('./render');
-const {testsVersion, pintfVersion} = require('./version');
+const {testsVersion, pentfVersion} = require('./version');
 const {loadTests} = require('./loader');
 
 // Available options:
@@ -41,7 +41,7 @@ async function real_main(options={}) {
 
     if (args.print_version) {
         console.log(await testsVersion(config));
-        console.log('pintf ' + pintfVersion());
+        console.log('pentf ' + pentfVersion());
         return;
     }
 

--- a/net_utils.js
+++ b/net_utils.js
@@ -29,7 +29,7 @@ async function fetch(config, url, options) {
         options.headers = {};
     }
     if (! Object.keys(options.headers).find(h => h.toLowerCase() === 'user-agent')) {
-        options.headers['User-Agent'] = 'pintf integration test (https://github.com/boxine/pintf)';
+        options.headers['User-Agent'] = 'pentf integration test (https://github.com/boxine/pentf)';
     }
 
     if (config.print_curl) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pintf",
+  "name": "pentf",
   "version": "1.0.52",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "pintf",
+  "name": "pentf",
   "version": "1.0.52",
-  "description": "parallel integration/end-to-end test framework",
+  "description": "parallel end-to-end test framework",
   "main": "index.js",
   "types": "index.d.ts",
   "directories": {
@@ -43,12 +43,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/boxine/pintf.git"
+    "url": "git+https://github.com/boxine/pentf.git"
   },
   "author": "Philipp Hagemeister, Boxine GmbH",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/boxine/pintf/issues"
+    "url": "https://github.com/boxine/pentf/issues"
   },
-  "homepage": "https://github.com/boxine/pintf#readme"
+  "homepage": "https://github.com/boxine/pentf#readme"
 }

--- a/pentf_example.js
+++ b/pentf_example.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
-const {getMail} = require('pintf/email');
-const {newPage, closePage} = require('pintf/browser_utils');
-const {fetch} = require('pintf/net_utils');
-const {makeRandomEmail} = require('pintf/utils');
+const {getMail} = require('pentf/email');
+const {newPage, closePage} = require('pentf/browser_utils');
+const {fetch} = require('pentf/net_utils');
+const {makeRandomEmail} = require('pentf/utils');
 
 async function run(config) {
-    const email = makeRandomEmail(config, 'pintf_example');
+    const email = makeRandomEmail(config, 'pentf_example');
     const start = new Date();
     const response = await fetch(config, 'https://api.tonie.cloud/v2/users', {
         method: 'POST',
@@ -41,7 +41,7 @@ async function run(config) {
 
 module.exports = {
     run,
-    description: 'pintf test example', // optional description for test reports, can be left out
+    description: 'pentf test example', // optional description for test reports, can be left out
 
     // You can skip the test in some conditions by defining an optional skip method:
     skip: config => config.env === 'prod',

--- a/promise_utils.js
+++ b/promise_utils.js
@@ -36,7 +36,7 @@ async function customErrorMessage(promise, error_message) {
 
 /**
  * Mark a code section as expected to fail.
- * @param {*} config The pintf configuration.
+ * @param {*} config The pentf configuration.
  * @param {string} message Error message to show when the section fails (recommended: ticket URL)
  * @param {() => any} asyncFunc The asynchronous section which is part of the test.
  * @param {{expectNothing?: boolean}} [options]
@@ -54,14 +54,14 @@ async function expectedToFail(config, message, asyncFunc, {expectNothing=false} 
     try {
         await asyncFunc();
     } catch(e) {
-        e.pintf_expectedToFail = message;
+        e.pentf_expectedToFail = message;
         throw e;
     }
     if (!config.expect_nothing) {
         const err = new Error(
             `Section marked as expectedToFail (${message}), but succeeded.` +
             ' Pass in --expect-nothing/-E to ignore this message');
-        err.pintf_expectedToSucceed = message;
+        err.pentf_expectedToSucceed = message;
         throw err;
     }
 }

--- a/render.js
+++ b/render.js
@@ -346,7 +346,7 @@ ${report_header_html}
 <p>Tested Environment: <strong>${results.config.env}</strong><br/>
 Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.concurrency}<br/>
 Start: ${format_timestamp(results.start)}<br/>
-Version: ${results.testsVersion}, pintf ${results.pintfVersion}<br/>
+Version: ${results.testsVersion}, pentf ${results.pentfVersion}<br/>
 </p>
 
 <h2>Results</h2>

--- a/run
+++ b/run
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-const pintf = require('./index.js');
+const pentf = require('./index.js');
 
 const lockserver = require('./lockserver/lockserver');
 
-pintf.main({
+pentf.main({
     rootDir: __dirname, // Mandatory
     // All further properties are optional
     beforeAllTests: lockserver.beforeAllTests,
     afterAllTests: lockserver.afterAllTests,
-    description: 'Test pintf itself',
+    description: 'Test pentf itself',
     defaultConfig: config => {
         // You can compute more complicated properties here. For example ...
         config.rejectUnauthorized = false; // Allow self-signed TLS certificates

--- a/runner.js
+++ b/runner.js
@@ -29,8 +29,8 @@ async function run_task(config, task) {
         task.status = 'error';
         task.duration = performance.now() - task.start;
         task.error = e;
-        if (e.pintf_expectedToFail) {
-            task.expectedToFail = e.pintf_expectedToFail;
+        if (e.pentf_expectedToFail) {
+            task.expectedToFail = e.pentf_expectedToFail;
         }
 
         if (config.take_screenshots) {
@@ -62,7 +62,7 @@ async function run_task(config, task) {
             !(config.ignore_errors && (new RegExp(config.ignore_errors)).test(e.stack)) &&
             (config.expect_nothing || !task.expectedToFail));
         if (show_error) {
-            if (e.pintf_expectedToSucceed) {
+            if (e.pentf_expectedToSucceed) {
                 output.log(
                     config, `PASSED test case ${task.name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
             } else {
@@ -288,12 +288,12 @@ async function run(config, testCases) {
     const test_end = Date.now();
 
     const testsVersion = await version.testsVersion(config);
-    const pintfVersion = version.pintfVersion();
+    const pentfVersion = version.pentfVersion();
 
     return {
         test_start,
         test_end,
-        pintfVersion,
+        pentfVersion,
         testsVersion,
         state,
     };

--- a/tests/browser_failure.js
+++ b/tests/browser_failure.js
@@ -18,5 +18,5 @@ module.exports = {
     description: 'Reproduces a browser failure. This is not a selftest; more of a demo.',
     resources: [],
     run,
-    skip: () => !process.env.PINTF_DEMO,
+    skip: () => !process.env.PENTF_DEMO,
 };

--- a/tests/glob_tests/run
+++ b/tests/glob_tests/run
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const pintf = require('../../index.js');
+const pentf = require('../../index.js');
 
-pintf.main({
+pentf.main({
     rootDir: __dirname,
     testsDir: __dirname,
     testsGlob: '*.spec.{js,jsx}'

--- a/tests/maxEventListeners_tests/run
+++ b/tests/maxEventListeners_tests/run
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const pintf = require('../../index.js');
+const pentf = require('../../index.js');
 
-pintf.main({
+pentf.main({
     rootDir: __dirname,
     testsDir: __dirname,
 });

--- a/tests/selftest_clickTestId.js
+++ b/tests/selftest_clickTestId.js
@@ -8,10 +8,10 @@ async function run(config) {
     const clicks = [];
 
     await page.setContent(`
-        <div data-testid="first" onclick="javascript:pintfClick('first')">first</div>
-        <div data-testid="invisible" style="display:none;" onclick="pintfClick('invisible')">invisible</div>
+        <div data-testid="first" onclick="javascript:pentfClick('first')">first</div>
+        <div data-testid="invisible" style="display:none;" onclick="pentfClick('invisible')">invisible</div>
     `);
-    await page.exposeFunction('pintfClick', clickId => {
+    await page.exposeFunction('pentfClick', clickId => {
         clicks.push(clickId);
     });
 

--- a/tests/test_lockserver.js
+++ b/tests/test_lockserver.js
@@ -6,9 +6,9 @@ const {wait, cmpKey} = require('../utils');
 
 
 async function run(config) {
-    assert(config.pintf_lockserver_url);
+    assert(config.pentf_lockserver_url);
 
-    const baseUrl = `${config.pintf_lockserver_url}test_lockserver_${Math.random().toString(36).slice(2)}`;
+    const baseUrl = `${config.pentf_lockserver_url}test_lockserver_${Math.random().toString(36).slice(2)}`;
     const config1 = {
         ...config,
         no_locking: false,

--- a/update-readme.js
+++ b/update-readme.js
@@ -21,7 +21,7 @@ function main() {
     const full_help = (child_process.execSync('./run --help', {
         env: {
             COLUMNS: 110,
-            PINTF_GENERIC_HELP: 'true',
+            PENTF_GENERIC_HELP: 'true',
         },
     }).toString('utf-8')
         .replace(/(-e\s+|\s--env\s+)\{[^}]*?\}/g, (_, key) => {

--- a/version.js
+++ b/version.js
@@ -29,11 +29,11 @@ async function testsVersion(config) {
     }
 }
 
-function pintfVersion() {
+function pentfVersion() {
     return require('./package.json').version;
 }
 
 module.exports = {
     testsVersion,
-    pintfVersion,
+    pentfVersion,
 };


### PR DESCRIPTION
While this project can be used for integration test, it is much more geared towards end-to-end tests.
Rename the project to follow as such.
This also clearly distinguishes it from printf, a technical term.

Add a project statement at the top of the README about pentf.